### PR TITLE
Github認証のスコープをやさしいものにして欲しい

### DIFF
--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,6 +1,6 @@
 Rails.application.config.middleware.use OmniAuth::Builder do
   # if Rails.env == 'development'
-  provider :github, ENV['GITHUB_KEY'], ENV['GITHUB_SECRET'], scope: "user,public_repo"
+  provider :github, ENV['GITHUB_KEY'], ENV['GITHUB_SECRET']
   # elsif Rails.env == 'production'
   #   provider :github, ENV['GITHUB_KEY_HEROKU'], ENV['GITHUB_SECRET_HEROKU '], scope: "user,repo"
   # end


### PR DESCRIPTION
Github認証で「このアプリに、あなたのリポジトリを変更する権限を許可します」みたいな怖いメッセージが出てきたので、デフォルトのスコープにした方がいいと思います。

これでもリポジトリの情報は取ってこれたので、現状の機能的には問題ないと思いますが…
どうでしょう